### PR TITLE
feat: Redesign package APIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,25 @@
 version: 2.1
 
+cache_key: &cache_key goutil-deps-20210108-{{ checksum "go.sum" }}
+
 jobs:
   lint-test:
     docker:
-      - image: circleci/golang:1.12
-    working_directory: ~/goutils
+      - image: cimg/go:1.15
     steps:
       - checkout
       - restore_cache:
           name: Restore dependency cache
           keys:
-            - goutils-deps-{{ checksum "go.sum" }}
+            - *cache_key
       - run:
           name: Install dependencies
           command: make setup
       - save_cache:
           name: Cache dependencies
-          key: goutils-deps-{{ checksum "go.sum" }}
+          key: *cache_key
           paths:
-            - /go/pkg
+            - ~/go/pkg
       - run:
           name: Run linter
           command: make lint

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # goutils
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/TouchBistro/goutils.svg)](https://pkg.go.dev/github.com/TouchBistro/goutils)
+
+A collection of useful go utilities. See [the docs](https://pkg.go.dev/github.com/TouchBistro/goutils) for more information.
+
+## Installation
+
+```
+go get github.com/TouchBistro/goutils
+```
+
+## License
+
+MIT © TouchBistro, see [LICENSE](LICENSE) for details.

--- a/color/color.go
+++ b/color/color.go
@@ -1,3 +1,4 @@
+// Package color provides functions for creating coloured strings.
 package color
 
 import (

--- a/color/color.go
+++ b/color/color.go
@@ -19,17 +19,21 @@ const (
 
 // Support for NO_COLOR env var
 // https://no-color.org/
-var noColor = false
+var (
+	noColor = false
+	enabled bool
+)
 
 func init() {
 	// The standard says the value doesn't matter, only whether or not it's set
 	if _, ok := os.LookupEnv("NO_COLOR"); ok {
 		noColor = true
 	}
+	enabled = !noColor
 }
 
 func apply(str string, start, end int) string {
-	if noColor {
+	if !enabled {
 		return str
 	}
 
@@ -37,6 +41,17 @@ func apply(str string, start, end int) string {
 	// Remove any occurrences of reset to make sure color isn't messed up
 	sanitized := regex.ReplaceAllString(str, "")
 	return fmt.Sprintf("\x1b[%dm%s\x1b[%dm", start, sanitized, end)
+}
+
+// SetEnabled sets whether color is enabled or disabled.
+// If the NO_COLOR environment variable is set, this function will
+// do nothing as NO_COLOR takes precedence.
+func SetEnabled(e bool) {
+	// NO_COLOR overrides this
+	if noColor {
+		return
+	}
+	enabled = e
 }
 
 // Red creates a red colored string

--- a/color/color_test.go
+++ b/color/color_test.go
@@ -1,59 +1,58 @@
-package color
+package color_test
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/TouchBistro/goutils/color"
 )
 
 func TestColors(t *testing.T) {
-	noColor = false
-
+	color.SetEnabled(true)
 	tests := []struct {
-		name     string
-		colorFn  func(string) string
-		input    string
-		expected string
+		name    string
+		colorFn func(string) string
+		input   string
+		want    string
 	}{
 		{
 			"Red() test",
-			Red,
+			color.Red,
 			"foo bar",
 			"\x1b[31mfoo bar\x1b[39m",
 		},
 		{
 			"Green() test",
-			Green,
+			color.Green,
 			"foo bar",
 			"\x1b[32mfoo bar\x1b[39m",
 		},
 		{
 			"Yellow() test",
-			Yellow,
+			color.Yellow,
 			"foo bar",
 			"\x1b[33mfoo bar\x1b[39m",
 		},
 		{
 			"Blue() test",
-			Blue,
+			color.Blue,
 			"foo bar",
 			"\x1b[34mfoo bar\x1b[39m",
 		},
 		{
 			"Magenta() test",
-			Magenta,
+			color.Magenta,
 			"foo bar",
 			"\x1b[35mfoo bar\x1b[39m",
 		},
 		{
 			"Cyan() test",
-			Cyan,
+			color.Cyan,
 			"foo bar",
 			"\x1b[36mfoo bar\x1b[39m",
 		},
 		{
 			"White() test",
-			White,
+			color.White,
 			"foo bar",
 			"\x1b[37mfoo bar\x1b[39m",
 		},
@@ -61,22 +60,28 @@ func TestColors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			received := tt.colorFn(tt.input)
-			assert.Equal(t, tt.expected, received)
+			got := tt.colorFn(tt.input)
+			if got != tt.want {
+				t.Errorf("got %s, want %s", got, tt.want)
+			}
 		})
 	}
 }
 
 func TestStripReset(t *testing.T) {
-	noColor = false
-
-	received := Red("foo \x1b[39mbar")
-	assert.Equal(t, "\x1b[31mfoo bar\x1b[39m", received)
+	color.SetEnabled(true)
+	got := color.Red("foo \x1b[39mbar")
+	want := "\x1b[31mfoo bar\x1b[39m"
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
 }
 
-func TestNoColor(t *testing.T) {
-	noColor = true
-
-	received := Red("foo bar")
-	assert.Equal(t, "foo bar", received)
+func TestColorDisabled(t *testing.T) {
+	color.SetEnabled(false)
+	got := color.Red("foo bar")
+	want := "foo bar"
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
 }

--- a/command/command.go
+++ b/command/command.go
@@ -1,3 +1,6 @@
+// Package command provides functionality for working with programs the host OS.
+// It provides a high level API over os/exec for running commands, which is
+// easier to use for common cases.
 package command
 
 import (

--- a/command/command.go
+++ b/command/command.go
@@ -11,10 +11,7 @@ import (
 // checking if command exists within the user's PATH.
 func IsAvailable(command string) bool {
 	_, err := exec.LookPath(command)
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 // Command manages the configuration of a command

--- a/command/command.go
+++ b/command/command.go
@@ -1,47 +1,113 @@
 package command
 
 import (
+	"fmt"
+	"io"
 	"os/exec"
 	"strings"
-
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
-func IsCommandAvailable(command string) bool {
+// IsAvailable checks if command is available on the system. This is done by
+// checking if command exists within the user's PATH.
+func IsAvailable(command string) bool {
 	_, err := exec.LookPath(command)
 	if err != nil {
-		log.WithFields(log.Fields{"error": err.Error(), "command": command}).Debug("Error looking up command.")
 		return false
 	}
 	return true
 }
 
-func Exec(cmdName string, args []string, id string, opts ...func(*exec.Cmd)) error {
-	cmd := exec.Command(cmdName, args...)
+// Command manages the configuration of a command
+// that will be run in a child process.
+type Command struct {
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+	env    map[string]string
+	dir    string
+}
 
-	stdout := log.WithFields(log.Fields{
-		"id": id,
-	}).WriterLevel(log.DebugLevel)
-	defer stdout.Close()
-
-	stderr := log.WithFields(log.Fields{
-		"id": id,
-	}).WriterLevel(log.DebugLevel)
-	defer stderr.Close()
-
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-
+// New creates a command instance from the given options.
+func New(opts ...Option) *Command {
+	c := &Command{}
 	for _, opt := range opts {
-		opt(cmd)
+		opt(c)
+	}
+	return c
+}
+
+// Option is a function that takes a command and applies
+// a configuration to it.
+type Option func(*Command)
+
+// WithStdin sets the reader the the command's stdin should read from.
+func WithStdin(stdin io.Reader) Option {
+	return func(c *Command) {
+		c.stdin = stdin
+	}
+}
+
+// WithStdout sets the writer that the command's stdout
+// should be written to.
+func WithStdout(stdout io.Writer) Option {
+	return func(c *Command) {
+		c.stdout = stdout
+	}
+}
+
+// WithStderr sets the writer that the command's stderr
+// should be written to.
+func WithStderr(stderr io.Writer) Option {
+	return func(c *Command) {
+		c.stderr = stderr
+	}
+}
+
+// WithEnv sets the environment variables for the process
+// the command will be run in.
+func WithEnv(env map[string]string) Option {
+	return func(c *Command) {
+		c.env = env
+	}
+}
+
+// WithDir sets the directory the command should be run in.
+func WithDir(dir string) Option {
+	return func(c *Command) {
+		c.dir = dir
+	}
+}
+
+// Exec executes the named program with the given arguments.
+func (c *Command) Exec(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	if c.stdin != nil {
+		cmd.Stdin = c.stdin
+	}
+	if c.stdout != nil {
+		cmd.Stdout = c.stdout
+	}
+	if c.stderr != nil {
+		cmd.Stderr = c.stderr
+	}
+	if c.env != nil {
+		for k, v := range c.env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
+	}
+	if c.dir != "" {
+		cmd.Dir = c.dir
 	}
 
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		argsStr := strings.Join(args, " ")
-		return errors.Wrapf(err, "Exec failed to run %s %s", cmdName, argsStr)
+		return fmt.Errorf("command: failed to run '%s %s': %w", name, argsStr, err)
 	}
-
 	return nil
+}
+
+// Exec executes the named program with the given arguments.
+// This is a shorthand for when the default command options wish to be used.
+func Exec(name string, args ...string) error {
+	return New().Exec(name, args...)
 }

--- a/fatal/fatal.go
+++ b/fatal/fatal.go
@@ -1,3 +1,6 @@
+// Package fatal provides functionality for terminating the program when a
+// fatal condition occurs. It allows for printing messages and errors and
+// running a clean up function before the program is terminated.
 package fatal
 
 import (

--- a/fatal/fatal_test.go
+++ b/fatal/fatal_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 )
 
 type mockExit struct {
@@ -45,8 +44,13 @@ func TestExit(t *testing.T) {
 
 	Exit("Something broke")
 
-	assert.Equal(t, 1, me.code)
-	assert.Equal(t, "Something broke\n", buf.String())
+	if me.code != 1 {
+		t.Errorf("got error code %d, expected 1", me.code)
+	}
+	want := "Something broke\n"
+	if buf.String() != want {
+		t.Errorf("got output %q, want %q", buf.String(), want)
+	}
 }
 
 func TestExitOnExit(t *testing.T) {
@@ -65,9 +69,16 @@ func TestExitOnExit(t *testing.T) {
 
 	Exit("Something broke")
 
-	assert.Equal(t, 1, me.code)
-	assert.Equal(t, "Something broke\n", buf.String())
-	assert.True(t, c.flushed)
+	if me.code != 1 {
+		t.Errorf("got error code %d, expected 1", me.code)
+	}
+	want := "Something broke\n"
+	if buf.String() != want {
+		t.Errorf("got output %q, want %q", buf.String(), want)
+	}
+	if !c.flushed {
+		t.Error("want flushed to be true, was false")
+	}
 }
 
 func TestExitf(t *testing.T) {
@@ -81,8 +92,13 @@ func TestExitf(t *testing.T) {
 
 	Exitf("%d failures", 3)
 
-	assert.Equal(t, 1, me.code)
-	assert.Equal(t, "3 failures\n", buf.String())
+	if me.code != 1 {
+		t.Errorf("got error code %d, expected 1", me.code)
+	}
+	want := "3 failures\n"
+	if buf.String() != want {
+		t.Errorf("got output %q, want %q", buf.String(), want)
+	}
 }
 
 func TestExitfOnExit(t *testing.T) {
@@ -101,9 +117,16 @@ func TestExitfOnExit(t *testing.T) {
 
 	Exitf("%d failures", 3)
 
-	assert.Equal(t, 1, me.code)
-	assert.Equal(t, "3 failures\n", buf.String())
-	assert.True(t, c.flushed)
+	if me.code != 1 {
+		t.Errorf("got error code %d, expected 1", me.code)
+	}
+	want := "3 failures\n"
+	if buf.String() != want {
+		t.Errorf("got output %q, want %q", buf.String(), want)
+	}
+	if !c.flushed {
+		t.Error("want flushed to be true, was false")
+	}
 }
 
 func TestExitErr(t *testing.T) {
@@ -119,8 +142,13 @@ func TestExitErr(t *testing.T) {
 
 	ExitErr(err, "Something broke")
 
-	assert.Equal(t, 1, me.code)
-	assert.Equal(t, "Something broke\nError: err everything broke\n", buf.String())
+	if me.code != 1 {
+		t.Errorf("got error code %d, expected 1", me.code)
+	}
+	want := "Something broke\nError: err everything broke\n"
+	if buf.String() != want {
+		t.Errorf("got output %q, want %q", buf.String(), want)
+	}
 }
 
 func TestExitErrStack(t *testing.T) {
@@ -138,13 +166,14 @@ func TestExitErrStack(t *testing.T) {
 
 	ExitErr(err, "Something broke")
 
-	assert.Equal(t, 1, me.code)
-
-	expected := "Something broke\n" +
+	if me.code != 1 {
+		t.Errorf("got error code %d, expected 1", me.code)
+	}
+	want := "Something broke\n" +
 		"Error: err everything broke\n" +
 		"github.com/TouchBistro/goutils/fatal.TestExitErrStack\n" +
 		"\t.+"
-	testFormatRegexp(t, 0, err, buf.String(), expected)
+	testFormatRegexp(t, 0, err, buf.String(), want)
 }
 
 func TestExitErrf(t *testing.T) {
@@ -160,8 +189,13 @@ func TestExitErrf(t *testing.T) {
 
 	ExitErrf(err, "%d failures", 3)
 
-	assert.Equal(t, 1, me.code)
-	assert.Equal(t, "3 failures\nError: err everything broke\n", buf.String())
+	if me.code != 1 {
+		t.Errorf("got error code %d, expected 1", me.code)
+	}
+	want := "3 failures\nError: err everything broke\n"
+	if buf.String() != want {
+		t.Errorf("got output %q, want %q", buf.String(), want)
+	}
 }
 
 func TestExitErrStackf(t *testing.T) {
@@ -179,13 +213,14 @@ func TestExitErrStackf(t *testing.T) {
 
 	ExitErrf(err, "%d failures", 3)
 
-	assert.Equal(t, 1, me.code)
-
-	expected := "3 failures\n" +
+	if me.code != 1 {
+		t.Errorf("got error code %d, expected 1", me.code)
+	}
+	want := "3 failures\n" +
 		"Error: err everything broke\n" +
 		"github.com/TouchBistro/goutils/fatal.TestExitErrStack\n" +
 		"\t.+"
-	testFormatRegexp(t, 0, err, buf.String(), expected)
+	testFormatRegexp(t, 0, err, buf.String(), want)
 }
 
 // Taken from https://github.com/pkg/errors/blob/614d223910a179a466c1767a985424175c39b465/format_test.go#L387

--- a/file/file.go
+++ b/file/file.go
@@ -1,156 +1,156 @@
 package file
 
 import (
-	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
-func FileOrDirExists(path string) bool {
+const mkdirDefaultPerms = 0o755
+
+// ErrNotDir indicates a path was not a directory.
+var ErrNotDir = errors.New("not a directory")
+
+// ErrNotRegularFile indicates a path was not a regular file.
+// For example, this could mean it was a symlink.
+var ErrNotRegularFile = errors.New("not a regular file")
+
+// Exists checks if a file or directory exists at path.
+func Exists(path string) bool {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return false
 	}
 	return true
 }
 
-func DownloadFile(downloadPath string, r io.Reader) (int64, error) {
+// Download creates or replaces a file at downloadPath by reading from r.
+func Download(downloadPath string, r io.Reader) (int64, error) {
 	// Check if file exists
 	downloadDir := filepath.Dir(downloadPath)
-	if !FileOrDirExists(downloadDir) {
-		err := os.MkdirAll(downloadDir, 0755)
-		if err != nil {
-			return 0, errors.Wrapf(err, "could not create directory %s", downloadDir)
-		}
+	if err := os.MkdirAll(downloadDir, mkdirDefaultPerms); err != nil {
+		return 0, fmt.Errorf("failed to create directory %q: %w", downloadDir, err)
 	}
 
 	// Write payload to target dir
 	f, err := os.Create(downloadPath)
 	if err != nil {
-		return 0, errors.Wrapf(err, "failed to create file %s", downloadPath)
+		return 0, fmt.Errorf("failed to create file %q: %w", downloadPath, err)
 	}
-	w := bufio.NewWriter(f)
-	nBytes, err := io.Copy(w, r)
+	defer f.Close()
+	n, err := io.Copy(f, r)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed writing build to file")
+		return 0, fmt.Errorf("failed writing data to file %q: %w", downloadPath, err)
 	}
-	w.Flush()
-
-	return nBytes, nil
+	return n, nil
 }
 
-func AppendLineToFile(path string, line string) error {
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+// CopyFile copies the regular file located at src to dst. Any intermediate directories in dst
+// that do not exists will be created. If src is not a regular file an error will be returned.
+func CopyFile(src, dst string) error {
+	info, err := os.Lstat(src)
 	if err != nil {
-		return errors.Wrapf(err, "failed to open file %s", path)
+		return fmt.Errorf("failed to get info of %q: %w", src, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: %q", ErrNotRegularFile, src)
+	}
+	return copyFile(src, dst, info)
+}
+
+// copyFile is the actual implementation of CopyFile. It assumes that src
+// has already been verified to be a regular file.
+func copyFile(src, dst string, info os.FileInfo) error {
+	dir := filepath.Dir(dst)
+	if err := os.MkdirAll(dir, mkdirDefaultPerms); err != nil {
+		return fmt.Errorf("failed to create directory %q: %w", dir, err)
+	}
+
+	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return fmt.Errorf("failed to open/create file %q: %w", dst, err)
 	}
 	defer f.Close()
 
-	_, err = f.WriteString(line + "\n")
-	return errors.Wrapf(err, "failed to write line %s to file %s", path, line)
-}
-
-func CreateFile(path string, content string) error {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	s, err := os.Open(src)
 	if err != nil {
-		return errors.Wrapf(err, "failed to open file %s", path)
+		return fmt.Errorf("failed to open source file %q: %w", src, err)
 	}
-	defer f.Close()
+	defer s.Close()
 
-	_, err = f.WriteString(content)
-	if err != nil {
-		return errors.Wrapf(err, "failed to write content to file %s", path)
+	if _, err = io.Copy(f, s); err != nil {
+		return fmt.Errorf("failed to copy %q to %q: %w", src, dst, err)
 	}
-
-	err = f.Sync()
-	return errors.Wrapf(err, "failed to commit write to disk writing to %s", path)
-}
-
-func CopyFile(srcPath, destPath string) error {
-	srcStat, err := os.Stat(srcPath)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get info of %s", srcPath)
-	}
-
-	if !srcStat.Mode().IsRegular() {
-		return errors.New(fmt.Sprintf("%s is not a file", srcPath))
-	}
-
-	srcFile, err := os.Open(srcPath)
-	if err != nil {
-		return errors.Wrapf(err, "failed to open file %s", srcPath)
-	}
-	defer srcFile.Close()
-
-	destFile, err := os.OpenFile(
-		destPath,
-		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
-		srcStat.Mode(),
-	)
-	if err != nil {
-		return errors.Wrapf(err, "failed to open file %s", destPath)
-	}
-	defer destFile.Close()
-
-	_, err = io.Copy(destFile, srcFile)
-	return errors.Wrapf(err, "failed to copy %s to %s", srcPath, destPath)
-}
-
-func CopyDirContents(srcPath, destPath string) error {
-	stat, err := os.Stat(srcPath)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get info of %s", srcPath)
-	}
-
-	if !stat.IsDir() {
-		return errors.New(fmt.Sprintf("%s is not a directory", srcPath))
-	}
-
-	err = os.MkdirAll(destPath, stat.Mode())
-	if err != nil {
-		return errors.Wrapf(err, "failed to create missing directories for destPath %s", destPath)
-	}
-
-	contents, err := ioutil.ReadDir(srcPath)
-	if err != nil {
-		return errors.Wrapf(err, "failed to read contents of %s", srcPath)
-	}
-
-	for _, item := range contents {
-		srcItemPath := fmt.Sprintf("%s/%s", srcPath, item.Name())
-		destItemPath := fmt.Sprintf("%s/%s", destPath, item.Name())
-
-		if !item.IsDir() {
-			err = CopyFile(srcItemPath, destItemPath)
-			if err != nil {
-				return errors.Wrapf(err, "failed to copy file %s", srcItemPath)
-			}
-
-			continue
-		}
-
-		err = CopyDirContents(srcItemPath, destItemPath)
-		if err != nil {
-			return errors.Wrapf(err, "failed to copy directory %s", srcItemPath)
-		}
-	}
-
 	return nil
 }
 
+// CopyDirContents copies all contents from the directory src to the directory dst.
+// Only regular files and directories will be copied. If src or dst is not a directory,
+// and error will be returned. If dst does not exists, it will be created.
+func CopyDirContents(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return fmt.Errorf("failed to get info of %q: %w", src, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%w: %q", ErrNotDir, src)
+	}
+	return copyDirContents(src, dst, info)
+}
+
+// copyDirContents is the actual implementation of CopyDirContents. It assumes that src
+// has already been verified to be a directory file.
+func copyDirContents(src, dst string, info os.FileInfo) error {
+	// Make sure dst exists, if it does this is a no-op
+	if err := os.MkdirAll(dst, info.Mode()); err != nil {
+		return fmt.Errorf("failed to create directory %q: %w", dst, err)
+	}
+
+	contents, err := ioutil.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("failed to read contents of directory %q: %w", src, err)
+	}
+
+	for _, item := range contents {
+		srcItemPath := filepath.Join(src, item.Name())
+		dstItemPath := filepath.Join(dst, item.Name())
+
+		if item.IsDir() {
+			err := copyDirContents(srcItemPath, dstItemPath, item)
+			if err != nil {
+				return fmt.Errorf("failed to copy directory %q: %w", srcItemPath, err)
+			}
+			continue
+		}
+		if !item.Mode().IsRegular() {
+			// Unsupported file type, ignore
+			continue
+		}
+
+		err := copyFile(srcItemPath, dstItemPath, item)
+		if err != nil {
+			return fmt.Errorf("failed to copy file %q: %w", srcItemPath, err)
+		}
+	}
+	return nil
+}
+
+// DirSize returns the size of the directory located at path.
 func DirSize(path string) (int64, error) {
-	if !FileOrDirExists(path) {
-		return 0, nil
+	s, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	if !s.IsDir() {
+		return 0, fmt.Errorf("%w: %q", ErrNotDir, path)
 	}
 
 	var size int64
-	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.Wrapf(err, "failed to walk %s", path)
+			return err
 		}
 		if !info.IsDir() {
 			size += info.Size()
@@ -160,6 +160,7 @@ func DirSize(path string) (int64, error) {
 	return size, err
 }
 
+// DirLen returns the number of items in the directory located at path.
 func DirLen(path string) (int, error) {
 	dir, err := os.Open(path)
 	if err != nil {

--- a/file/file.go
+++ b/file/file.go
@@ -1,3 +1,4 @@
+// Package file provides various helpers for working with files on an OS filesystem.
 package file
 
 import (

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -1,22 +1,229 @@
-package file
+package file_test
 
 import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/TouchBistro/goutils/file"
 )
 
-func TestDirExists(t *testing.T) {
-	path := "testdata/text_tests"
-	assert.True(t, FileOrDirExists(path))
+func TestExists(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"dir exists", "testdata/text_tests", true},
+		{"file exists", "testdata/text_tests/hype.md", true},
+		{"does not exists", "testdata/notafile.txt", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := file.Exists(tt.path)
+			if got != tt.want {
+				t.Errorf("got %t, want %t", got, tt.want)
+			}
+		})
+	}
 }
 
-func TestFileExists(t *testing.T) {
-	path := "testdata/text_tests/hype.md"
-	assert.True(t, FileOrDirExists(path))
+func TestDownload(t *testing.T) {
+	tmpdir := t.TempDir()
+	downloadPath := filepath.Join(tmpdir, "builds", "release.build")
+	const content = `pretend this is a really important file
+	use your imagination`
+	r := strings.NewReader(content)
+	n, err := file.Download(downloadPath, r)
+	if err != nil {
+		t.Errorf("want nil error, got %v", err)
+	}
+	wantN := int64(len(content))
+	if n != wantN {
+		t.Errorf("got %d bytes written, want %d", n, wantN)
+	}
+
+	// Make sure file was actually written
+	data, err := ioutil.ReadFile(downloadPath)
+	if err != nil {
+		t.Fatalf("failed to read file %v", err)
+	}
+	gotContent := string(data)
+	if gotContent != content {
+		t.Errorf("got %q, want %q", gotContent, content)
+	}
 }
 
-func TestFileNotExists(t *testing.T) {
-	path := "testdata/notafile.txt"
-	assert.False(t, FileOrDirExists(path))
+func TestCopyFile(t *testing.T) {
+	tmpdir := t.TempDir()
+	src := filepath.Join(tmpdir, "src")
+	dst := filepath.Join(tmpdir, "dst")
+	const content = `this is some file content`
+	err := ioutil.WriteFile(src, []byte(content), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write file %v", err)
+	}
+
+	err = file.CopyFile(src, dst)
+	if err != nil {
+		t.Errorf("want nil error, got %v", err)
+	}
+	data, err := ioutil.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read file %v", err)
+	}
+	gotContent := string(data)
+	if gotContent != content {
+		t.Errorf("got %q, want %q", gotContent, content)
+	}
+}
+
+func TestCopyFileNotRegularFile(t *testing.T) {
+	tmpdir := t.TempDir()
+	src := filepath.Join(tmpdir, "src")
+	dst := filepath.Join(tmpdir, "dst")
+	err := os.MkdirAll(src, 0o755)
+	if err != nil {
+		t.Fatalf("failed to create dir %v", err)
+	}
+
+	err = file.CopyFile(src, dst)
+	if !errors.Is(err, file.ErrNotRegularFile) {
+		t.Errorf("got %v err, want %v", err, file.ErrNotRegularFile)
+	}
+}
+
+func TestCopyDirContents(t *testing.T) {
+	tmpdir := t.TempDir()
+	src := filepath.Join(tmpdir, "src")
+	dst := filepath.Join(tmpdir, "dst")
+	err := os.MkdirAll(filepath.Join(src, "foodir"), 0o755)
+	if err != nil {
+		t.Fatalf("failed to create dir: %s", err)
+	}
+	const barfileContent = "bar"
+	err = ioutil.WriteFile(filepath.Join(src, "barfile"), []byte(barfileContent), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create file: %s", err)
+	}
+	const bazfileContent = "baz"
+	err = ioutil.WriteFile(filepath.Join(src, "foodir", "bazfile"), []byte(bazfileContent), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create file: %s", err)
+	}
+
+	err = file.CopyDirContents(src, dst)
+	if err != nil {
+		t.Errorf("want nil error, got %v", err)
+	}
+
+	data, err := ioutil.ReadFile(filepath.Join(dst, "barfile"))
+	if err != nil {
+		t.Fatalf("failed to read file %v", err)
+	}
+	gotContent := string(data)
+	if gotContent != barfileContent {
+		t.Errorf("got %q, want %q", gotContent, barfileContent)
+	}
+
+	data, err = ioutil.ReadFile(filepath.Join(dst, "foodir", "bazfile"))
+	if err != nil {
+		t.Fatalf("failed to read file %v", err)
+	}
+	gotContent = string(data)
+	if gotContent != bazfileContent {
+		t.Errorf("got %q, want %q", gotContent, bazfileContent)
+	}
+}
+
+func TestCopyDirContentsNotDir(t *testing.T) {
+	tmpdir := t.TempDir()
+	src := filepath.Join(tmpdir, "src")
+	dst := filepath.Join(tmpdir, "dst")
+	const content = `this is some file content`
+	err := ioutil.WriteFile(src, []byte(content), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write file %v", err)
+	}
+
+	err = file.CopyDirContents(src, dst)
+	if !errors.Is(err, file.ErrNotDir) {
+		t.Errorf("got %v err, want %v", err, file.ErrNotDir)
+	}
+}
+
+func TestDirSize(t *testing.T) {
+	tmpdir := t.TempDir()
+	err := os.Mkdir(filepath.Join(tmpdir, "foodir"), 0o755)
+	if err != nil {
+		t.Fatalf("failed to create dir: %s", err)
+	}
+	const barfileContent = "bar"
+	err = ioutil.WriteFile(filepath.Join(tmpdir, "barfile"), []byte(barfileContent), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create file: %s", err)
+	}
+	const bazfileContent = "baz"
+	err = ioutil.WriteFile(filepath.Join(tmpdir, "foodir", "bazfile"), []byte(bazfileContent), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create file: %s", err)
+	}
+
+	size, err := file.DirSize(tmpdir)
+	if err != nil {
+		t.Errorf("want nil error, got %v", err)
+	}
+	// Size should be at least this much, but allow it to be more
+	// in case there are filesystem shenanigans
+	minSize := int64(len(barfileContent) + len(bazfileContent))
+	if size < minSize {
+		t.Errorf("got dir size %d, want it to be min %d", size, minSize)
+	}
+}
+
+func TestDirSizeNotDir(t *testing.T) {
+	tmpdir := t.TempDir()
+	const barfileContent = "bar"
+	barfilePath := filepath.Join(tmpdir, "barfile")
+	err := ioutil.WriteFile(barfilePath, []byte(barfileContent), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create file: %s", err)
+	}
+
+	size, err := file.DirSize(barfilePath)
+	if !errors.Is(err, file.ErrNotDir) {
+		t.Errorf("got %v err, want %v", err, file.ErrNotDir)
+	}
+	if size != 0 {
+		t.Errorf("got %d, want 0", size)
+	}
+}
+
+func TestDirLen(t *testing.T) {
+	tmpdir := t.TempDir()
+	err := os.Mkdir(filepath.Join(tmpdir, "foodir"), 0o755)
+	if err != nil {
+		t.Fatalf("failed to create dir: %s", err)
+	}
+	err = ioutil.WriteFile(filepath.Join(tmpdir, "barfile"), []byte("bar"), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create file: %s", err)
+	}
+	err = ioutil.WriteFile(filepath.Join(tmpdir, "bazfile"), []byte("baz"), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create file: %s", err)
+	}
+
+	n, err := file.DirLen(tmpdir)
+	if err != nil {
+		t.Errorf("want nil error, got %v", err)
+	}
+	want := 3
+	if n != want {
+		t.Errorf("got dir len %d, want %d", n, want)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,5 @@
 module github.com/TouchBistro/goutils
 
-go 1.13
+go 1.15
 
-require (
-	github.com/pkg/errors v0.9.1
-	github.com/sirupsen/logrus v1.4.2
-	github.com/stretchr/testify v1.2.2
-)
+require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,2 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
-github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
-github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
-golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -18,7 +18,7 @@ var frames = [...]string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧",
 type Spinner struct {
 	interval time.Duration
 	w        io.Writer
-	mu       *sync.RWMutex
+	mu       *sync.Mutex
 	// stopChan is used to stop the spinner
 	stopChan chan struct{}
 	active   bool
@@ -46,7 +46,7 @@ func New(opts ...Option) *Spinner {
 	s := &Spinner{
 		interval: 100 * time.Millisecond,
 		w:        os.Stderr,
-		mu:       &sync.RWMutex{},
+		mu:       &sync.Mutex{},
 		stopChan: make(chan struct{}, 1),
 		active:   false,
 		// default to 1 since we don't show progress on 1 anyway
@@ -182,6 +182,13 @@ func (s *Spinner) IncWithMessage(m string) {
 // reached full progress, IncWithMessagef does nothing.
 func (s *Spinner) IncWithMessagef(format string, args ...interface{}) {
 	s.IncWithMessage(fmt.Sprintf(format, args...))
+}
+
+// UpdateMessage changes the current message being shown by the spinner.
+func (s *Spinner) UpdateMessage(m string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.setMsg(m)
 }
 
 // setMsg sets the spinner message to m. If m is longer then s.maxMsgLen it will

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -2,70 +2,235 @@ package spinner
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"runtime"
 	"strings"
+	"sync"
 	"time"
-
-	"github.com/TouchBistro/goutils/fatal"
-	log "github.com/sirupsen/logrus"
+	"unicode/utf8"
 )
 
-func spinnerBar(total int) func(int) {
-	spinnerFrames := []string{"|", "/", "-", "\\"}
-	progress := 0
-	animState := 0
-	return func(inc int) {
-		progress += inc
-		var bar strings.Builder
-		bar.WriteString("\r")
-		bar.WriteString(spinnerFrames[animState])
-		bar.WriteString(" [")
-		for i := 0; i < total; i++ {
-			if progress > i {
-				bar.WriteString("#")
-			} else {
-				bar.WriteString("-")
-			}
+var frames = [...]string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// Spinner represents the state of the spinner.
+type Spinner struct {
+	interval time.Duration
+	out      io.Writer
+	mu       *sync.RWMutex
+	// stopChan is used to stop the spinner
+	stopChan chan struct{}
+	active   bool
+	// last string written to out
+	lastOutput string
+	startMsg   string
+	stopMsg    string
+	// msg written on each frame
+	msg string
+	// total number of items
+	count int
+	// number of items completed
+	completed int
+	maxMsgLen int
+}
+
+// New creates a new spinner instance using the given options.
+func New(opts ...Option) *Spinner {
+	s := &Spinner{
+		interval: 100 * time.Millisecond,
+		out:      os.Stderr,
+		mu:       &sync.RWMutex{},
+		stopChan: make(chan struct{}, 1),
+		active:   false,
+		// default to 1 since we don't show progress on 1 anyway
+		count:     1,
+		maxMsgLen: 80,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// Option is a function that takes a spinner and applies
+// a configuration to it.
+type Option func(*Spinner)
+
+// WithInterval sets how often the spinner updates.
+// This controls the speed of the spinner.
+// By default the interval is 100ms.
+func WithInterval(d time.Duration) Option {
+	return func(s *Spinner) {
+		s.interval = d
+	}
+}
+
+// WithWriter sets the writer that should be used for writting the spinner to.
+func WithWriter(w io.Writer) Option {
+	return func(s *Spinner) {
+		s.out = w
+	}
+}
+
+// WithStartMessage sets a string that should be written after the spinner
+// when the spinnner is started.
+func WithStartMessage(m string) Option {
+	return func(s *Spinner) {
+		s.startMsg = m
+	}
+}
+
+// WithStopMessage sets a string that should be written when the spinner is stopped.
+// This message will replace the spinner.
+func WithStopMessage(m string) Option {
+	return func(s *Spinner) {
+		s.stopMsg = m
+	}
+}
+
+// WithCount sets the total number of items to track the progress of.
+func WithCount(c int) Option {
+	return func(s *Spinner) {
+		s.count = c
+	}
+}
+
+// WithMaxMessageLength sets the maximum length of the message that is written
+// by the spinner. If the message is longer then this length it will be truncated.
+// The default max length is 80.
+func WithMaxMessageLength(l int) Option {
+	return func(s *Spinner) {
+		s.maxMsgLen = l
+	}
+}
+
+// Start will start the spinner.
+// If the spinner is already running, Start will do nothing.
+func (s *Spinner) Start() {
+	s.mu.Lock()
+	if s.active {
+		s.mu.Unlock()
+		return
+	}
+	s.active = true
+	s.setMsg(s.startMsg)
+	s.mu.Unlock()
+	go s.run()
+}
+
+// Stop stops the spinner if it is currently running.
+// If the spinner is not running, Stop will do nothing.
+func (s *Spinner) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.active {
+		return
+	}
+
+	s.active = false
+	s.erase()
+	if s.stopMsg != "" {
+		// Make sure there's a trailing newline
+		if s.stopMsg[len(s.stopMsg)-1] != '\n' {
+			s.stopMsg += "\n"
 		}
-		bar.WriteString("]")
-		animState++
-		animState = animState % len(spinnerFrames)
-		fmt.Print(bar.String())
-		if progress == total {
-			clearLine(total + 4)
+		fmt.Fprint(s.out, s.stopMsg)
+	}
+	s.stopChan <- struct{}{}
+}
+
+// Inc increments the progress of the spinner. If the spinner
+// has already reached full progress, Inc does nothing.
+func (s *Spinner) Inc() {
+	s.IncWithMessage("")
+}
+
+// IncWithMessage increments the progress of the spinner and updates
+// the spinner message to m. If the spinner has already reached
+// full progress, IncWithMessage does nothing.
+func (s *Spinner) IncWithMessage(m string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.completed >= s.count {
+		return
+	}
+	s.completed++
+	s.setMsg(m)
+}
+
+// IncWithMessagef increments the progress of the spinner and updates
+// the spinner message to the format specifier. If the spinner has already
+// reached full progress, IncWithMessagef does nothing.
+func (s *Spinner) IncWithMessagef(format string, args ...interface{}) {
+	s.IncWithMessage(fmt.Sprintf(format, args...))
+}
+
+// setMsg sets the spinner message to m. If m is longer then s.maxMsgLen it will
+// be truncated. If m is empty, setMsg will do nothing.
+// The caller must already hold s.lock.
+func (s *Spinner) setMsg(m string) {
+	if m == "" {
+		return
+	}
+	// Truncate msg if it's too long
+	if len(m) > s.maxMsgLen {
+		// DISCUSS(@cszatmary): Should the ... count as part of the length or no?
+		m = m[:s.maxMsgLen] + "..."
+	}
+	// Make sure message has a leading space to pad between it and the
+	// spinner icon
+	if m[0] != ' ' {
+		m = " " + m
+	}
+	s.msg = m
+}
+
+// run runs the spinner. It should be called in a separate goroutine because
+// it will run forever until it receives a value on s.stopChan.
+func (s *Spinner) run() {
+	for {
+		for i := 0; i < len(frames); i++ {
+			select {
+			case <-s.stopChan:
+				return
+			default:
+				s.mu.Lock()
+				if !s.active {
+					s.mu.Unlock()
+					return
+				}
+				s.erase()
+
+				line := fmt.Sprintf("\r%s%s ", frames[i], s.msg)
+				if s.count > 1 {
+					line += fmt.Sprintf("(%d/%d) ", s.completed, s.count)
+				}
+				fmt.Fprint(s.out, line)
+				s.lastOutput = line
+				d := s.interval
+
+				s.mu.Unlock()
+				time.Sleep(d)
+			}
 		}
 	}
 }
 
-func clearLine(length int) {
-	var b strings.Builder
-	for i := 0; i < length; i++ {
-		b.WriteString(" ")
+// erase deletes written characters. The caller must already hold s.lock.
+func (s *Spinner) erase() {
+	n := utf8.RuneCountInString(s.lastOutput)
+	if runtime.GOOS == "windows" {
+		clearString := "\r" + strings.Repeat(" ", n) + "\r"
+		fmt.Fprint(s.out, clearString)
+		s.lastOutput = ""
+		return
 	}
-	fmt.Printf("\r")
-	fmt.Print(b.String())
-	fmt.Printf("\r")
-}
 
-func SpinnerWait(successCh chan string, failedCh chan error, successMsg string, failedMsg string, count int) {
-	spin := spinnerBar(count)
-	for i := 0; i < count; {
-		select {
-		case name := <-successCh:
-			if !log.IsLevelEnabled(log.DebugLevel) {
-				clearLine(count + 4)
-			}
-			log.Infof(successMsg, name)
-			i++
-			if !log.IsLevelEnabled(log.DebugLevel) {
-				spin(1)
-			}
-		case err := <-failedCh:
-			fmt.Printf("\r\n")
-			fatal.ExitErrf(err, failedMsg)
-		case <-time.After(time.Second / 10):
-			if !log.IsLevelEnabled(log.DebugLevel) {
-				spin(0)
-			}
-		}
+	// "\033[K" for macOS Terminal
+	for _, c := range []string{"\b", "\127", "\b", "\033[K"} {
+		fmt.Fprint(s.out, strings.Repeat(c, n))
 	}
+	// erases to end of line
+	fmt.Fprintf(s.out, "\r\033[K")
+	s.lastOutput = ""
 }

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -203,9 +203,9 @@ func (s *Spinner) setMsg(m string) {
 		m = m[:len(m)-1]
 	}
 	// Truncate msg if it's too long
-	if len(m) > s.maxMsgLen {
-		// DISCUSS(@cszatmary): Should the ... count as part of the length or no?
-		m = m[:s.maxMsgLen] + "..."
+	const ellipses = "..."
+	if len(m)-len(ellipses) > s.maxMsgLen {
+		m = m[:s.maxMsgLen-len(ellipses)] + ellipses
 	}
 	// Make sure message has a leading space to pad between it and the spinner icon
 	if m[0] != ' ' {

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -1,3 +1,5 @@
+// Package spinner provides a spinner that can be used to display progress to a user
+// in a command line application.
 package spinner
 
 import (
@@ -14,7 +16,18 @@ import (
 
 var frames = [...]string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
-// Spinner represents the state of the spinner.
+// Spinner represents the state of the spinner. A spinner can be created
+// using the spinner.New function.
+//
+// Spinner can keep track of and display progress through a list of items
+// that need to be completed.
+//
+// Spinner implements the io.Writer interface. It can be written to in order
+// to print messages while the spinner is running. It is not recommended to
+// write directly to the writer the spinner is writing to (by default stderr),
+// as it can cause issues with the spinner animation. Writing to the spinner
+// directly provides a way to get around this limitation, as the spinner will
+// ensure that the text will be written properly without interfering with the animation.
 type Spinner struct {
 	interval time.Duration
 	w        io.Writer
@@ -145,7 +158,7 @@ func (s *Spinner) Stop() {
 
 	s.active = false
 	s.stopChan <- struct{}{}
-	// Add last msg as a debug msg before we do the final erase.
+	// Persist last msg before we do the final erase.
 	// Need to do this manually since we aren't using setMsg
 	s.persistMsg()
 	s.erase()

--- a/spinner/spinner_test.go
+++ b/spinner/spinner_test.go
@@ -1,0 +1,163 @@
+package spinner_test
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/TouchBistro/goutils/spinner"
+)
+
+type syncBuffer struct {
+	sync.Mutex
+	bytes.Buffer
+}
+
+func (b *syncBuffer) Write(data []byte) (int, error) {
+	b.Lock()
+	defer b.Unlock()
+	return b.Buffer.Write(data)
+}
+
+func TestSpinner(t *testing.T) {
+	out := &syncBuffer{}
+	s := spinner.New(spinner.WithWriter(out))
+	s.Start()
+	time.Sleep(500 * time.Millisecond)
+	s.Stop()
+
+	// wait a bit because the spinner still has to erase before stopping
+	time.Sleep(100 * time.Millisecond)
+	got := out.String()
+	// Should be 5 frames since we ran for 500ms and it's 1 frame per 100ms
+	want := "⠋⠙⠹⠸⠼"
+	// Check that frames were actually written
+	if !containsAll(got, want) {
+		t.Errorf("got %q, want to contain all %q", got, want)
+	}
+}
+
+func TestSpinnerCounter(t *testing.T) {
+	const count = 3
+	out := &syncBuffer{}
+	s := spinner.New(
+		spinner.WithInterval(50*time.Millisecond),
+		spinner.WithWriter(out),
+		spinner.WithStartMessage("Cloning repos"),
+		spinner.WithStopMessage("Cloned all repos"),
+		spinner.WithCount(count),
+	)
+	s.Start()
+	for i := 1; i < count+1; i++ {
+		time.Sleep(75 * time.Millisecond)
+		s.Inc()
+	}
+	s.Stop()
+
+	// wait a bit because the spinner still has to erase before stopping
+	time.Sleep(50 * time.Millisecond)
+	got := out.String()
+
+	// Should be at least 4 frames
+	wantFrames := "⠋⠙⠹⠸"
+	if !containsAll(got, wantFrames) {
+		t.Errorf("got %q, want to contain all %q", got, wantFrames)
+	}
+
+	// Asserting the output is a bit tricky because of the special erase codes written
+	// to erase the text in terminals.
+	// Just make sure that the text we expect appears in the output
+	wantMsgs := []string{
+		"Cloning repos (0/3)",
+		"Cloning repos (1/3)",
+		"Cloning repos (2/3)",
+		"Cloned all repos",
+	}
+	for _, wantMsg := range wantMsgs {
+		if !strings.Contains(got, wantMsg) {
+			t.Errorf("got %q, want to contain %q", got, wantMsg)
+		}
+	}
+}
+
+func TestSpinnerCounterMessage(t *testing.T) {
+	const count = 3
+	out := &syncBuffer{}
+	s := spinner.New(
+		spinner.WithInterval(50*time.Millisecond),
+		spinner.WithWriter(out),
+		spinner.WithStartMessage("Cloning repos"),
+		spinner.WithStopMessage("Cloned all repos"),
+		spinner.WithCount(count),
+	)
+	s.Start()
+	for i := 1; i < count+1; i++ {
+		time.Sleep(75 * time.Millisecond)
+		s.IncWithMessagef("Cloned repo %d", i)
+	}
+	s.Stop()
+
+	// wait a bit because the spinner still has to erase before stopping
+	time.Sleep(50 * time.Millisecond)
+	got := out.String()
+
+	// Should be at least 4 frames
+	wantFrames := "⠋⠙⠹⠸"
+	if !containsAll(got, wantFrames) {
+		t.Errorf("got %q, want to contain all %q", got, wantFrames)
+	}
+
+	// Asserting the output is a bit tricky because of the special erase codes written
+	// to erase the text in terminals.
+	// Just make sure that the text we expect appears in the output
+	wantMsgs := []string{
+		"Cloning repos (0/3)",
+		"Cloned repo 1 (1/3)",
+		"Cloned repo 2 (2/3)",
+		"Cloned all repos",
+	}
+	for _, wantMsg := range wantMsgs {
+		if !strings.Contains(got, wantMsg) {
+			t.Errorf("got %q, want to contain %q", got, wantMsg)
+		}
+	}
+}
+
+func TestSpinnerMaxMessageLength(t *testing.T) {
+	out := &syncBuffer{}
+	s := spinner.New(
+		spinner.WithInterval(50*time.Millisecond),
+		spinner.WithWriter(out),
+		spinner.WithStartMessage("This message is way too long"),
+		spinner.WithMaxMessageLength(10),
+	)
+	s.Start()
+	time.Sleep(150 * time.Millisecond)
+	s.Stop()
+
+	// wait a bit because the spinner still has to erase before stopping
+	time.Sleep(50 * time.Millisecond)
+	got := out.String()
+
+	// Should be at least 2 frames
+	wantFrames := "⠋⠙"
+	if !containsAll(got, wantFrames) {
+		t.Errorf("got %q, want to contain all %q", got, wantFrames)
+	}
+
+	wantMsg := "This messa..."
+	if !strings.Contains(got, wantMsg) {
+		t.Errorf("got %q, want to contain %q", got, wantMsg)
+	}
+}
+
+func containsAll(s string, chars string) bool {
+	for _, r := range chars {
+		if !strings.ContainsRune(s, r) {
+			return false
+		}
+	}
+	return true
+}

--- a/spinner/spinner_test.go
+++ b/spinner/spinner_test.go
@@ -258,7 +258,7 @@ func TestSpinnerMaxMessageLength(t *testing.T) {
 		spinner.WithInterval(10*time.Millisecond),
 		spinner.WithWriter(out),
 		spinner.WithStartMessage("This message is way too long"),
-		spinner.WithMaxMessageLength(10),
+		spinner.WithMaxMessageLength(15),
 	)
 	s.Start()
 	time.Sleep(15 * time.Millisecond)
@@ -274,7 +274,7 @@ func TestSpinnerMaxMessageLength(t *testing.T) {
 		t.Errorf("got %q, want to contain all %q", got, wantFrames)
 	}
 
-	wantMsg := "This messa..."
+	wantMsg := "This message..."
 	if !strings.Contains(got, wantMsg) {
 		t.Errorf("got %q, want to contain %q", got, wantMsg)
 	}


### PR DESCRIPTION
* Completely redesigned the `spinner` package. New spinner with support for progress messages and logging while the spinner is running.
* Redesigned `command` package. The API is easier to use and is driven by functional options.
* Redesigned the `files` package to have clearer function names.
* Ensured all packages are documented and thoroughly tested.
* Removed the need for various dependencies. Most notably all tests now use only the `testing` package from the standard library, no more third party assertion library.