### PR TITLE
feat!: Redesign fatal package

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 )
 
-// IsAvailable checks if command is available on the system. This is done by
-// checking if command exists within the user's PATH.
-func IsAvailable(command string) bool {
+// Exists checks if the command exists on the system by seeing if it's in the user's PATH.
+func Exists(command string) bool {
 	_, err := exec.LookPath(command)
 	return err == nil
 }

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -8,17 +8,30 @@ import (
 	"github.com/TouchBistro/goutils/command"
 )
 
-func TestIsAvailable(t *testing.T) {
-	exists := command.IsAvailable("echo")
-	if !exists {
-		t.Error("want command to exist but it does not")
+func TestExists(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{
+			name:    "command exists",
+			command: "echo",
+			want:    true,
+		},
+		{
+			name:    "command does not exists",
+			command: "thiscannotpossiblyexist1234",
+			want:    false,
+		},
 	}
-}
-
-func TestNotIsAvailable(t *testing.T) {
-	exists := command.IsAvailable("asljhasld")
-	if exists {
-		t.Error("want command to not exist but it does")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := command.Exists(tt.command)
+			if got != tt.want {
+				t.Errorf("got %t for exists, want %t", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/fatal/fatal.go
+++ b/fatal/fatal.go
@@ -1,6 +1,35 @@
-// Package fatal provides functionality for terminating the program when a
-// fatal condition occurs. It allows for printing messages and errors and
-// running a clean up function before the program is terminated.
+// Package fatal provides functionality for dealing with fatal errors
+// and handling program termination.
+//
+// A fatal error is an error from which the program has no reasonable way to
+// recover from and therefore the program cannot continue running.
+//
+// It is important to note that a fatal error is distinct from a panic
+// and fatal should be used in different situations. A panic should occur
+// when something unexpected happens and the program cannot recover.
+// Examples of this are programming errors such as the program ending up in an
+// impossible state, or a runtime error such as the program running out of memory.
+// In these cases the program should panic in order to abort as quickly and loudly
+// as possible to alert users of the issue.
+//
+// A fatal error on the other hand is an error that can reasonably occur in a program
+// and is not unexpected, but is also unrecoverable. Examples of this are a config file
+// was unable to be read, or a user provided an invalid argument. These cases are not
+// exceptional and should do not deserve panics, however there is likely no way to recover
+// from them. Instead the program should exit with a meaningful exit code as well as
+// a message informing the user of what went wrong and how to proceed.
+//
+// The fatal package provides two primary mechanisms to support dealing with these sitations.
+//
+// The Error type represents a fatal error that occurred. It allows signaling that the program
+// should exit with a given exit code. It also allows for adding a message that describes
+// the problem along with the underlying error that occurred.
+//
+// The Exiter type provides the ability to exit the program based on an error. The Exiter.Exit
+// method takes an error and determines the exit code from it. The Exiter.PrintAndExit method
+// is similar, but it also prints a description of the error before exiting to provide context.
+// The top level Exit and PrintAndExit functions are provided for convenience and offer the
+// functionality provided by Exiter with defaults.
 package fatal
 
 import (
@@ -9,64 +38,148 @@ import (
 	"os"
 )
 
-// Package state
-var (
-	printDetailedError = false
-	onExitHandler      func()
-)
-
-// Used for dependency injection in tests
-// Normally having tests touch private stuff is bad
-// but this is the only way I could figure out to mock os.Exit
-var (
-	errWriter io.Writer      = os.Stderr
-	exitFunc  func(code int) = os.Exit
-)
-
-// PrintDetailedError sets whether or not a detailed version of an error
-// should be printed when calling ExitErr or ExitErrf.
+// ExitCoder defines a type that can provide an exit code.
 //
-// A detailed error is printed by using the '%+v' format verb.
-func PrintDetailedError(show bool) {
-	printDetailedError = show
+// The value returned by the ExitCode method is up to interpretation
+// by the caller. For example, certain APIs might only deal with error
+// cases and might treat a value of 0 as meaning an exit code was not
+// specified and default it to 1 instead.
+type ExitCoder interface {
+	ExitCode() int
 }
 
-// OnExit registers a handler that will run before os.Exit is called.
-// This is useful for performing any clean up that would usually be called
-// in a defer block since defers are not called when os.Exit is used.
-func OnExit(handler func()) {
-	onExitHandler = handler
+// Error is used to communicate that a program should exit.
+// It represents a fatal (but not unexpected) error that cannot be recovered from.
+// The fields can be used to control how the program exits.
+//
+// Error implements the error interface for convenience so it can be returned as
+// an error value from functions. However, Error should be treated specially and
+// not like a normal error.
+//
+// There are two rules that should be followed when working with Error:
+//
+// 1. An Error instance should always be a top level error and should not be wrapped.
+//
+// 2. The Error method should generally not be used. Instead it should be used with a
+// printf-like function using either the '%v' or '%+v' verbs. This will create a nice
+// message from the error that can be displayed to users to provide information on what
+// went wrong and offer guidance on how to proceed.
+type Error struct {
+	// Code is the code that the program should exit with.
+	Code int
+	// Msg is a message to print to provide information on what went wrong
+	// and how to proceed.
+	Msg string
+	// Err is the underlying error that occurred (if any).
+	Err error
 }
 
-// ExitErr prints the given message and error to stderr then exits the program.
-func ExitErr(err error, message string) {
-	fmt.Fprintln(errWriter, message)
-	if err != nil {
-		if printDetailedError {
-			fmt.Fprintf(errWriter, "Error: %+v\n", err)
-		} else {
-			fmt.Fprintf(errWriter, "Error: %s\n", err)
+// ExitCode implements the ExitCoder interface and returns the error's code.
+func (e *Error) ExitCode() int {
+	return e.Code
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprint(e)
+}
+
+func (e *Error) Format(s fmt.State, verb rune) {
+	if e.Err != nil {
+		_, _ = io.WriteString(s, "Error: ")
+		format := "%v\n"
+		if s.Flag('+') {
+			format = "%+v\n"
 		}
+		fmt.Fprintf(s, format, e.Err)
 	}
-	if onExitHandler != nil {
-		onExitHandler()
+	// If an error was just printed and a message is going to be printed,
+	// add an extra newline inbetween them.
+	if e.Err != nil && e.Msg != "" {
+		_, _ = io.WriteString(s, "\n")
 	}
-	exitFunc(1)
+	if e.Msg != "" {
+		// If e.Msg ends with a newline remove it so that callers can control
+		// whether or not to add a newline with a printf-like function.
+		// We could use strings.HasSuffix and strings.TrimSuffix but it's just a single
+		// byte/rune so lets do it ourselves and avoid a dependency on the strings package.
+		msg := e.Msg
+		if msg[len(msg)-1] == '\n' {
+			msg = msg[:len(msg)-1]
+		}
+		_, _ = io.WriteString(s, msg)
+	}
 }
 
-// ExitErrf prints the given message and error to stderr then exits the program.
-// Supports printf like formatting.
-func ExitErrf(err error, format string, a ...interface{}) {
-	ExitErr(err, fmt.Sprintf(format, a...))
+func (e *Error) Unwrap() error {
+	return e.Err
 }
 
-// Exit prints the given message to stderr then exists the program.
-func Exit(message string) {
-	ExitErr(nil, message)
+// Exiter is used to terminate a program.
+// The fields can be used to customize how the program exits.
+type Exiter struct {
+	// Out is where the error should be printed when using PrintAndExit.
+	// If nil, it will be defaulted to os.Stderr.
+	Out io.Writer
+	// PrintDetailed controls how the error is formatted when using PrintAndExit.
+	// If true, the error is formatted using '%+v', otherwise '%v' is used.
+	PrintDetailed bool
+	// ExitFunc is the function that will be called to exit the program.
+	// A custom function can be provided to control exit behaviour and perform
+	// additional tasks before exiting.
+	// If nil, it will be defaulted to os.Exit.
+	ExitFunc func(code int)
 }
 
-// Exitf prints the given message to stderr then exits the program.
-// Supports printf like formatting.
-func Exitf(format string, a ...interface{}) {
-	ExitErr(nil, fmt.Sprintf(format, a...))
+// Exit causes the program to exit. The exit code is determined based on err.
+// If err implements ExitCoder and the value of ExitCode is greater than zero,
+// it will be used. Otherwise, the exit code will be 1.
+func (e *Exiter) Exit(err error) {
+	var code int
+	if ec, ok := err.(ExitCoder); ok {
+		code = ec.ExitCode()
+	}
+	// If the code couldn't be determined or an invalid code was provided,
+	// default to code to 1 since that is the general catch all error code.
+	// Exit should not be used to exit successfully so assume 0 means not provided
+	// even if it was the actual value.
+	if code < 1 {
+		code = 1
+	}
+	if e.ExitFunc == nil {
+		e.ExitFunc = os.Exit
+	}
+	e.ExitFunc(code)
+}
+
+// PrintAndExit prints the error and then causes the program to exit.
+// The exit code is determined based on err. If err implements ExitCoder
+// and the value of ExitCode is greater than zero, it will be used.
+// Otherwise, the exit code will be 1.
+func (e *Exiter) PrintAndExit(err error) {
+	format := "%v\n"
+	if e.PrintDetailed {
+		format = "%+v\n"
+	}
+	if e.Out == nil {
+		e.Out = os.Stderr
+	}
+	fmt.Fprintf(e.Out, format, err)
+	e.Exit(err)
+}
+
+// Exit causes the program to exit. The exit code is determined based on err.
+// If err implements ExitCoder and the value of ExitCode is greater than zero,
+// it will be used. Otherwise, the exit code will be 1.
+func Exit(err error) {
+	var e Exiter
+	e.Exit(err)
+}
+
+// PrintAndExit prints the error and then causes the program to exit.
+// The exit code is determined based on err. If err implements ExitCoder
+// and the value of ExitCode is greater than zero, it will be used.
+// Otherwise, the exit code will be 1.
+func PrintAndExit(err error) {
+	var e Exiter
+	e.PrintAndExit(err)
 }

--- a/progress/run.go
+++ b/progress/run.go
@@ -70,7 +70,7 @@ type RunParallelOptions struct {
 	Count int
 	// Concurrency controls how many goroutines can run concurrently.
 	// Defaults to runtime.NumCPU if omitted.
-	Concurrency uint
+	Concurrency int
 	// CancelOnError determines how Run should behave if a function returns an error.
 	// If true, Run will immediately return an error and cancel all other running functions.
 	// If false, Run will let the other functions continue and will return an errors.List
@@ -104,7 +104,7 @@ func RunParallel(ctx context.Context, opts RunParallelOptions, fn RunParallelFun
 		// Always provide a timeout to make sure the program doesn't hang and run forever.
 		opts.Timeout = defaultTimeout
 	}
-	if opts.Concurrency == 0 {
+	if opts.Concurrency < 1 {
 		opts.Concurrency = DefaultConcurrency()
 	}
 
@@ -156,11 +156,11 @@ func RunParallel(ctx context.Context, opts RunParallelOptions, fn RunParallelFun
 
 // DefaultConcurrency returns default concurrency that should be used for parallel operations
 // by using runtime.NumCPU.
-func DefaultConcurrency() uint {
+func DefaultConcurrency() int {
 	// Check for negative number just to be safe since the type is int.
 	// Better safe than sorry and having an overflow.
 	if numCPUs := runtime.NumCPU(); numCPUs > 0 {
-		return uint(numCPUs)
+		return numCPUs
 	}
 	// If we get here somehow just execute everything serially.
 	return 1


### PR DESCRIPTION
Redesign the fatal package to focus on treating exit conditions as errors and having a single exit point instead of exiting whenever wherever.

Right now the fatal package makes it too easy to exit from anywhere and as a result we have adopted a bad practice of exiting from programs all over the place. This makes it hander to control the flow of a program and handle things like common clean up before exiting.

These changes should make it easier to exit with an error the right way and harder to do it the wrong way.